### PR TITLE
James/is release2

### DIFF
--- a/CHANGE.md
+++ b/CHANGE.md
@@ -1,0 +1,8 @@
+# Change Log
+
+## 1.1.0 (Unreleased)
+* Added `isRelease()` to `Version` interface to allow for determining of release version
+* By default substitute `/` for `_` in branch names to add maven compatibility out of the box.
+
+## 1.0.1
+* Initial release

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The unreleased version format can be configured:
 ```groovy
 gitflow {
     // Customise template for unreleased version (uses freemarker)
-    unreleasedVersionTemplate "${major}.${minor}.${patch}-${branch}.${commitsSinceLastTag}+sha.${commitId?substring(0,7)}${dirty?then('.dirty','')}"
+    unreleasedVersionTemplate "${major}.${minor}.${patch}-${branch?replace('/', '_')}.${commitsSinceLastTag}+sha.${commitId?substring(0,7)}${dirty?then('.dirty','')}"
 }
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,4 @@ bintray.pkg {
     websiteUrl = "https://github.com/jamesridgway/gradle-gitflow-plugin"
     issueTrackerUrl = "https://github.com/jamesridgway/gradle-gitflow-plugin/issues"
     vcsUrl = "${websiteUrl}.git"
-
 }
-

--- a/gradle/bintray.gradle
+++ b/gradle/bintray.gradle
@@ -1,4 +1,3 @@
-import uk.co.jamesridgway.gradle.gitflow.plugin.version.ReleaseVersion
 bintray {
     if (project.hasProperty('bintrayUser')) {
         user = project.getProperties().get("bintrayUser")
@@ -24,6 +23,6 @@ bintray {
     }
 }
 
-if (version instanceof ReleaseVersion) {
+if (version.isRelease()) {
     publish.dependsOn bintrayUpload
 }

--- a/src/main/java/uk/co/jamesridgway/gradle/gitflow/plugin/GitFlowPluginExtension.java
+++ b/src/main/java/uk/co/jamesridgway/gradle/gitflow/plugin/GitFlowPluginExtension.java
@@ -9,14 +9,13 @@ public class GitFlowPluginExtension {
 
     public GitFlowPluginExtension(final Project project) {
         unreleasedVersionTemplate = project.property(String.class);
-            unreleasedVersionTemplate.set("${major}.${minor}.${patch}-${branch}.${commitsSinceLastTag}+sha."
-                    + "${commitId?substring(0,7)}${dirty?then('.dirty','')}");
+        unreleasedVersionTemplate.set("${major}.${minor}.${patch}-${branch?replace('/', '_')}."
+                + "${commitsSinceLastTag}+sha.${commitId?substring(0,7)}${dirty?then('.dirty','')}");
     }
 
     public String getUnreleaseVersionTemplate() {
         return unreleasedVersionTemplate.get();
     }
-
 
 
 }

--- a/src/main/java/uk/co/jamesridgway/gradle/gitflow/plugin/version/Version.java
+++ b/src/main/java/uk/co/jamesridgway/gradle/gitflow/plugin/version/Version.java
@@ -8,6 +8,10 @@ public interface Version {
 
     String getPatch();
 
+    default boolean isRelease() {
+        return this instanceof ReleaseVersion;
+    }
+
     default String getVersionString() {
         return String.format("%s.%s.%s", getMajor(), getMinor(), getPatch());
     }

--- a/src/test/java/uk/co/jamesridgway/gradle/gitflow/plugin/GitFlowPluginTest.java
+++ b/src/test/java/uk/co/jamesridgway/gradle/gitflow/plugin/GitFlowPluginTest.java
@@ -63,7 +63,7 @@ public class GitFlowPluginTest {
 
         assertThat(project.getVersion())
                 .isInstanceOf(UnreleasedVersion.class)
-                .hasToString("1.0.0-feature/james/FEAT-1.2+sha." + shortCommitId);
+                .hasToString("1.0.0-feature_james_FEAT-1.2+sha." + shortCommitId);
     }
 
 }

--- a/src/test/java/uk/co/jamesridgway/gradle/gitflow/plugin/version/GitFlowVersionProviderTest.java
+++ b/src/test/java/uk/co/jamesridgway/gradle/gitflow/plugin/version/GitFlowVersionProviderTest.java
@@ -100,7 +100,7 @@ public class GitFlowVersionProviderTest {
 
         assertThat(gitFlowVersionProvider.getVersion(project))
                 .isInstanceOf(UnreleasedVersion.class)
-                .hasToString("1.0.0-feature/james/FEAT-1.2+sha." + shortCommitId);
+                .hasToString("1.0.0-feature_james_FEAT-1.2+sha." + shortCommitId);
     }
 
     @Test
@@ -128,7 +128,7 @@ public class GitFlowVersionProviderTest {
 
         assertThat(gitFlowVersionProvider.getVersion(project))
                 .isInstanceOf(UnreleasedVersion.class)
-                .hasToString("1.0.0-feature/james/FEAT-1.1+sha." + shortCommitId + ".dirty");
+                .hasToString("1.0.0-feature_james_FEAT-1.1+sha." + shortCommitId + ".dirty");
     }
 
     private void ignoreCurrentUntrackedChanges() throws Exception {

--- a/src/test/java/uk/co/jamesridgway/gradle/gitflow/plugin/version/ReleaseVersionTest.java
+++ b/src/test/java/uk/co/jamesridgway/gradle/gitflow/plugin/version/ReleaseVersionTest.java
@@ -24,7 +24,12 @@ public class ReleaseVersionTest {
         assertThat(releaseVersion.getMinor()).isEqualTo(2);
         assertThat(releaseVersion.getPatch()).isEqualTo("3");
         assertThat(releaseVersion.toString()).isEqualTo("1.2.3");
+    }
 
+    @Test
+    public void isRelease() {
+        final ReleaseVersion releaseVersion = new ReleaseVersion(1, 0, 0);
+        assertThat(releaseVersion.isRelease()).isTrue();
     }
 
     @Test

--- a/src/test/java/uk/co/jamesridgway/gradle/gitflow/plugin/version/UnknownVersionTest.java
+++ b/src/test/java/uk/co/jamesridgway/gradle/gitflow/plugin/version/UnknownVersionTest.java
@@ -15,4 +15,10 @@ public class UnknownVersionTest {
         assertThat(unknownVersion.toString()).isEqualTo("0.0.0");
     }
 
+    @Test
+    public void isNotRelease() {
+        Version unknownVersion = new UnknownVersion();
+        assertThat(unknownVersion.isRelease()).isFalse();
+    }
+
 }

--- a/src/test/java/uk/co/jamesridgway/gradle/gitflow/plugin/version/UnreleasedVersionTest.java
+++ b/src/test/java/uk/co/jamesridgway/gradle/gitflow/plugin/version/UnreleasedVersionTest.java
@@ -3,8 +3,6 @@ package uk.co.jamesridgway.gradle.gitflow.plugin.version;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 public class UnreleasedVersionTest {
 
@@ -13,10 +11,7 @@ public class UnreleasedVersionTest {
         final String template = "${major}.${minor}.${patch}-${branch}.${commitsSinceLastTag}"
                 + "+sha.${commitId?substring(0,7)}${dirty?then('.dirty','')}";
 
-        ReleaseVersion releaseVersion = mock(ReleaseVersion.class);
-        when(releaseVersion.getMajor()).thenReturn(2);
-        when(releaseVersion.getMinor()).thenReturn(14);
-        when(releaseVersion.getPatch()).thenReturn("3");
+        ReleaseVersion releaseVersion = new ReleaseVersion(2, 14, 3);
 
         UnreleasedVersion unreleasedVersion = UnreleasedVersion.build(releaseVersion, template)
                 .withBranch("feature/test")
@@ -29,8 +24,18 @@ public class UnreleasedVersionTest {
         assertThat(unreleasedVersion.getMinor()).isEqualTo(14);
         assertThat(unreleasedVersion.getPatch()).isEqualTo("3");
         assertThat(unreleasedVersion.toString()).isEqualTo("2.14.3-feature/test.6+sha.a3dcb3e.dirty");
+    }
 
-
+    @Test
+    public void isNotRelease() {
+        ReleaseVersion releaseVersion = new ReleaseVersion(2, 14, 3);
+        UnreleasedVersion unreleasedVersion = UnreleasedVersion.build(releaseVersion, "")
+                .withBranch("feature/test")
+                .withCommitId("a3dcb3e")
+                .withCommitsSinceLastTag(6)
+                .withDirty(true)
+                .create();
+        assertThat(unreleasedVersion.isRelease()).isFalse();
     }
 
 }


### PR DESCRIPTION
**Version#isRelease**
Added `isRelease()` to `Version` interface to allow for determining of release version.

This means isRelease() can be used in gradle files without having to check the instance type of `version`.

**Substitute / for _ in branch names**
By default substitute `/` for `_` in branch names to add maven compatibility out of the box.

**Change log**
Also started to record an official change log