### PR TITLE
Optimise most recent tag lookup.

### DIFF
--- a/src/main/java/uk/co/jamesridgway/gradle/gitflow/plugin/GitFlowPlugin.java
+++ b/src/main/java/uk/co/jamesridgway/gradle/gitflow/plugin/GitFlowPlugin.java
@@ -13,7 +13,7 @@ public class GitFlowPlugin implements Plugin<Project> {
                 .create("gitflow", GitFlowPluginExtension.class, project);
 
         GitFlowVersionProvider versionProvider = new GitFlowVersionProvider(gitFlowPluginExtension);
-        Version version = versionProvider.getVersion(project);
+        Version version = versionProvider.getVersion(project.getRootDir());
 
         project.setVersion(version);
     }

--- a/src/main/java/uk/co/jamesridgway/gradle/gitflow/plugin/GitFlowPluginExtension.java
+++ b/src/main/java/uk/co/jamesridgway/gradle/gitflow/plugin/GitFlowPluginExtension.java
@@ -2,20 +2,19 @@ package uk.co.jamesridgway.gradle.gitflow.plugin;
 
 import org.gradle.api.Project;
 import org.gradle.api.provider.Property;
+import uk.co.jamesridgway.gradle.gitflow.plugin.version.GitFlowVersionConfig;
 
-public class GitFlowPluginExtension {
+public class GitFlowPluginExtension implements GitFlowVersionConfig {
 
     private final Property<String> unreleasedVersionTemplate;
 
     public GitFlowPluginExtension(final Project project) {
         unreleasedVersionTemplate = project.getObjects().property(String.class);
-        unreleasedVersionTemplate.set("${major}.${minor}.${patch}-${branch?replace('/', '_')}."
-                + "${commitsSinceLastTag}+sha.${commitId?substring(0,7)}${dirty?then('.dirty','')}");
+        unreleasedVersionTemplate.set(GitFlowVersionConfig.DEFAULT.getUnreleaseVersionTemplate());
     }
 
+    @Override
     public String getUnreleaseVersionTemplate() {
         return unreleasedVersionTemplate.get();
     }
-
-
 }

--- a/src/main/java/uk/co/jamesridgway/gradle/gitflow/plugin/Main.java
+++ b/src/main/java/uk/co/jamesridgway/gradle/gitflow/plugin/Main.java
@@ -1,0 +1,27 @@
+package uk.co.jamesridgway.gradle.gitflow.plugin;
+
+import uk.co.jamesridgway.gradle.gitflow.plugin.version.GitFlowVersionConfig;
+import uk.co.jamesridgway.gradle.gitflow.plugin.version.GitFlowVersionProvider;
+
+import java.io.File;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+public class Main {
+
+    private Main() {
+    }
+
+    public static void main(final String[] args) {
+
+        checkArgument(args.length == 1, "Requires 1 arg pointing to project dir");
+
+        File file = new File(args[0]);
+
+        checkArgument(file.exists() && file.isDirectory(), "Arg must be an existing directory");
+
+        GitFlowVersionProvider versionProvider = new GitFlowVersionProvider(GitFlowVersionConfig.DEFAULT);
+
+        System.out.println("Git Flow Version: " + versionProvider.getVersion(file));
+    }
+}

--- a/src/main/java/uk/co/jamesridgway/gradle/gitflow/plugin/git/DistanceToTags.java
+++ b/src/main/java/uk/co/jamesridgway/gradle/gitflow/plugin/git/DistanceToTags.java
@@ -1,0 +1,57 @@
+package uk.co.jamesridgway.gradle.gitflow.plugin.git;
+
+import com.google.common.base.MoreObjects;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.stream.Collectors.joining;
+
+public class DistanceToTags {
+
+    private final List<Tag> tags = new ArrayList<>();
+    private final int distance;
+
+    public DistanceToTags(final List<Tag> tags, final int distance) {
+        checkArgument(!tags.isEmpty(), "Must have at least one tag");
+        this.tags.addAll(tags);
+        this.distance = distance;
+    }
+
+    public List<Tag> getTags() {
+        return tags;
+    }
+
+    public int getDistance() {
+        return distance;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        DistanceToTags that = (DistanceToTags) o;
+        return Objects.equals(tags, that.tags)
+                && Objects.equals(distance, that.distance);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(tags, distance);
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+                .add("distance", getDistance())
+                .add("commit", tags.get(0).getCommit().getCommitId())
+                .add("tags", tags.stream().map(Tag::getShortTagName).collect(joining(",")))
+                .toString();
+    }
+}

--- a/src/main/java/uk/co/jamesridgway/gradle/gitflow/plugin/utils/Exceptions.java
+++ b/src/main/java/uk/co/jamesridgway/gradle/gitflow/plugin/utils/Exceptions.java
@@ -14,4 +14,17 @@ public class Exceptions {
             throw new RuntimeException(e);
         }
     }
+
+    public static void propagateAnyError(final Action action) {
+        try {
+            action.perform();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @FunctionalInterface
+    public interface Action {
+        void perform() throws Exception;
+    }
 }

--- a/src/main/java/uk/co/jamesridgway/gradle/gitflow/plugin/version/GitFlowVersionConfig.java
+++ b/src/main/java/uk/co/jamesridgway/gradle/gitflow/plugin/version/GitFlowVersionConfig.java
@@ -1,0 +1,11 @@
+package uk.co.jamesridgway.gradle.gitflow.plugin.version;
+
+public interface GitFlowVersionConfig {
+
+    GitFlowVersionConfig DEFAULT = () ->
+            "${major}.${minor}.${patch}-${branch?replace('/', '_')}."
+                    + "${commitsSinceLastTag}+sha.${commitId?substring(0,7)}${dirty?then('.dirty','')}";
+
+    String getUnreleaseVersionTemplate();
+
+}

--- a/src/main/java/uk/co/jamesridgway/gradle/gitflow/plugin/version/GitFlowVersionProvider.java
+++ b/src/main/java/uk/co/jamesridgway/gradle/gitflow/plugin/version/GitFlowVersionProvider.java
@@ -1,38 +1,33 @@
 package uk.co.jamesridgway.gradle.gitflow.plugin.version;
 
-import org.gradle.api.Project;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import uk.co.jamesridgway.gradle.gitflow.plugin.GitFlowPluginExtension;
 import uk.co.jamesridgway.gradle.gitflow.plugin.git.Commit;
+import uk.co.jamesridgway.gradle.gitflow.plugin.git.DistanceToTags;
 import uk.co.jamesridgway.gradle.gitflow.plugin.git.GitProject;
 import uk.co.jamesridgway.gradle.gitflow.plugin.git.Tag;
 
-import java.util.List;
-import java.util.NavigableMap;
+import java.io.File;
 import java.util.Optional;
 import java.util.Set;
-import java.util.TreeMap;
-import java.util.stream.Collectors;
 
 import static java.util.stream.Collectors.toSet;
 
-public class GitFlowVersionProvider implements VersionProvider {
+public class GitFlowVersionProvider {
 
     private static final Logger L = LoggerFactory.getLogger(GitFlowVersionProvider.class);
 
     static final Version UNKNOWN_VERSION = new UnknownVersion();
 
-    private final GitFlowPluginExtension gitFlowPluginExtension;
+    private final GitFlowVersionConfig config;
 
-    public GitFlowVersionProvider(final GitFlowPluginExtension gitFlowPluginExtension) {
-        this.gitFlowPluginExtension = gitFlowPluginExtension;
+    public GitFlowVersionProvider(final GitFlowVersionConfig config) {
+        this.config = config;
     }
 
-    @Override
-    public Version getVersion(final Project project) {
+    public Version getVersion(final File file) {
 
-        final GitProject gitProject = new GitProject(project);
+        final GitProject gitProject = new GitProject(file);
 
         if (!gitProject.hasHeadCommit()) {
             L.warn("No HEAD commit found, using version: {}", UNKNOWN_VERSION.getVersionString());
@@ -65,30 +60,29 @@ public class GitFlowVersionProvider implements VersionProvider {
             return Optional.empty();
         }
 
-        Commit headCommit = gitProject.getHeadCommit().get();
+        Optional<DistanceToTags> distanceToMostRecentTag = gitProject.getDistanceToMostRecentTags(tags);
 
-        NavigableMap<Integer, List<Tag>> ancestorTags = new TreeMap<>(tags.stream()
-                .filter(t -> headCommit.hasAncestorOf(t.getCommit()))
-                .filter(t -> ReleaseVersion.parse(t.getShortTagName()).isPresent())
-                .collect(Collectors.groupingBy(t -> headCommit.getDistanceFrom(t.getCommit()))));
-
-        if (ancestorTags.isEmpty()) {
+        if (!distanceToMostRecentTag.isPresent()) {
             return Optional.empty();
         }
 
-        final int distanceFromLastTag = ancestorTags.firstEntry().getKey();
-        final Set<ReleaseVersion> closestTags = ancestorTags.firstEntry().getValue().stream()
+        final Set<ReleaseVersion> releaseVersions = distanceToMostRecentTag.get().getTags().stream()
                 .map(tag -> ReleaseVersion.parse(tag.getShortTagName()).get())
-                .collect(Collectors.toSet());
-        final ReleaseVersion latestReleaseVersion = ReleaseVersion.findLatest(closestTags).get();
+                .collect(toSet());
+
+        final ReleaseVersion latestReleaseVersion = ReleaseVersion.findLatest(releaseVersions).get();
+        final String commitId = gitProject.getHeadCommit().get().getCommitId();
+        final int distanceFromLastTag = distanceToMostRecentTag.get().getDistance();
 
         UnreleasedVersion unreleasedVersion = UnreleasedVersion.build(latestReleaseVersion,
-                gitFlowPluginExtension.getUnreleaseVersionTemplate())
+                config.getUnreleaseVersionTemplate())
                 .withCommitsSinceLastTag(distanceFromLastTag)
-                .withCommitId(headCommit.getCommitId())
+                .withCommitId(commitId)
                 .withBranch(gitProject.getBranchName())
                 .withDirty(gitProject.isDirty())
                 .create();
+
         return Optional.of(unreleasedVersion);
+
     }
 }


### PR DESCRIPTION
 * Isolate VersionProvider from gradle framework classes.
 * Added Main class to allow easier testing.
 * Move to simpler, more performant approach for finding latest Tag by looking back through the history for the most recent tag.
   This replaces existing algorithm which finds the distance between the HEAD and each tag, and then filters to find the closest.