### PR TITLE
Using commits since last tag as the PATCH version.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The unreleased version format can be configured:
 ```groovy
 gitflow {
     // Customise template for unreleased version (uses freemarker)
-    unreleasedVersionTemplate "${major}.${minor}.${patch}-${branch?replace('/', '_')}.${commitsSinceLastTag}+sha.${commitId?substring(0,7)}${dirty?then('.dirty','')}"
+    unreleasedVersionTemplate "${major}.${minor}.${patch}.${commitsSinceLastTag}-${branch?replace('/', '_')}+sha.${commitId?substring(0,7)}${dirty?then('.dirty','')}"
 }
 ```
 
@@ -50,12 +50,12 @@ For any commit that is not tagged with a release version (`major.minor.patch`) a
 
 By default, an unreleased version is as follows:
 
-    0.0.1-feature/test1.1+sha.8661cfd.dirty
-    | | | |             |     |       |
-    | | | |             |     |       └ "dirty" is ppended if the commit is dirty
-    | | | |             |     └ Short commit id
-    | | | |             └ Number of commits since last tag
-    | | | └ Branch name
+    0.0.1.1-feature/test1+sha.8661cfd.dirty
+    | | | | |                 |       |
+    | | | | |                 |       └ "dirty" is ppended if the commit is dirty
+    | | | | |                 └ Short commit id
+    | | | | └ Branch name
+    | | | └ Number of commits since last tag
     | | └ Patch version for last release version
     | └ Minor version for last release version
     └ Major version for last release version

--- a/src/main/java/uk/co/jamesridgway/gradle/gitflow/plugin/version/GitFlowVersionConfig.java
+++ b/src/main/java/uk/co/jamesridgway/gradle/gitflow/plugin/version/GitFlowVersionConfig.java
@@ -3,8 +3,8 @@ package uk.co.jamesridgway.gradle.gitflow.plugin.version;
 public interface GitFlowVersionConfig {
 
     GitFlowVersionConfig DEFAULT = () ->
-            "${major}.${minor}.${patch}-${branch?replace('/', '_')}."
-                    + "${commitsSinceLastTag}+sha.${commitId?substring(0,7)}${dirty?then('.dirty','')}";
+            "${major}.${minor}.${patch}.${commitsSinceLastTag}-${branch?replace('/', '_')}"
+                    + "+sha.${commitId?substring(0,7)}${dirty?then('.dirty','')}";
 
     String getUnreleaseVersionTemplate();
 

--- a/src/test/java/uk/co/jamesridgway/gradle/gitflow/plugin/GitFlowPluginTest.java
+++ b/src/test/java/uk/co/jamesridgway/gradle/gitflow/plugin/GitFlowPluginTest.java
@@ -63,7 +63,7 @@ public class GitFlowPluginTest {
 
         assertThat(project.getVersion())
                 .isInstanceOf(UnreleasedVersion.class)
-                .hasToString("1.0.0-feature_james_FEAT-1.2+sha." + shortCommitId);
+                .hasToString("1.0.0.2-feature_james_FEAT-1+sha." + shortCommitId);
     }
 
 }

--- a/src/test/java/uk/co/jamesridgway/gradle/gitflow/plugin/version/GitFlowVersionProviderTest.java
+++ b/src/test/java/uk/co/jamesridgway/gradle/gitflow/plugin/version/GitFlowVersionProviderTest.java
@@ -100,7 +100,7 @@ public class GitFlowVersionProviderTest {
 
         assertThat(gitFlowVersionProvider.getVersion(project.getRootDir()))
                 .isInstanceOf(UnreleasedVersion.class)
-                .hasToString("2.0.0-master.1+sha." + shortCommitId);
+                .hasToString("2.0.0.1-master+sha." + shortCommitId);
     }
 
     @Test
@@ -118,7 +118,7 @@ public class GitFlowVersionProviderTest {
 
         assertThat(gitFlowVersionProvider.getVersion(project.getRootDir()))
                 .isInstanceOf(UnreleasedVersion.class)
-                .hasToString("1.0.0-master.0+sha." + shortCommitId + ".dirty");
+                .hasToString("1.0.0.0-master+sha." + shortCommitId + ".dirty");
     }
 
     @Test
@@ -147,7 +147,7 @@ public class GitFlowVersionProviderTest {
 
         assertThat(gitFlowVersionProvider.getVersion(project.getRootDir()))
                 .isInstanceOf(UnreleasedVersion.class)
-                .hasToString("1.0.0-feature_james_FEAT-1.2+sha." + shortCommitId);
+                .hasToString("1.0.0.2-feature_james_FEAT-1+sha." + shortCommitId);
     }
 
     @Test
@@ -175,7 +175,7 @@ public class GitFlowVersionProviderTest {
 
         assertThat(gitFlowVersionProvider.getVersion(project.getRootDir()))
                 .isInstanceOf(UnreleasedVersion.class)
-                .hasToString("1.0.0-feature_james_FEAT-1.1+sha." + shortCommitId + ".dirty");
+                .hasToString("1.0.0.1-feature_james_FEAT-1+sha." + shortCommitId + ".dirty");
     }
 
     private void ignoreCurrentUntrackedChanges() throws Exception {


### PR DESCRIPTION
Gradle versioning uses lexical ordering of the qualifier so it considers "1.2.3-something" less than "1.2.3".

This means that gradle treats unreleased versions as being less than released versions.

This uses `commitsSinceLastTag` as the patch version so each additional commit on a tag should naturally be seen as greater than the previous commits